### PR TITLE
Use bldenv rather than nightly, and supply an env file

### DIFF
--- a/components/openindiana/gfx-drm/Makefile
+++ b/components/openindiana/gfx-drm/Makefile
@@ -19,19 +19,19 @@ COMPONENT_NAME=		gfx-drm
 COMPONENT_SRC=		$(COMPONENT_NAME)
 
 GIT=git
-GIT_REPO=https://github.com/alarcher/gfx-drm
+#GIT_REPO=git://github.com/gwr/gfx-drm.git
+GIT_REPO=git://github.com/alarcher/gfx-drm.git
 GIT_BRANCH=drm3
 GIT_CHANGESET=HEAD
 
+FETCH=$(WS_TOOLS)/userland-fetch
+
 RELEASE_MINOR=3
 ONNV_BUILDNUM=$(BRANCHID)
+
 COMPONENT_REVISION=$(shell cd $(COMPONENT_SRC); git rev-list HEAD --count)
 
-GFX_DRM_REPO=$(SOURCE_DIR)/packages/$(MACH)/nightly-nd/repo.gfx-drm
-
-# The code is not lint clean: do not pass -l
-# Do not check proto area as we do not install drm headers -N
-NIGHTLY_OPTIONS=-nmprtN
+GFX_DRM_REPO=$(SOURCE_DIR)/packages/$(MACH)/nightly-nd/repo.skel
 
 CLEAN_PATHS += $(BUILD_DIR)
 CLOBBER_PATHS += $(SOURCE_DIR)
@@ -53,36 +53,22 @@ download:: $(SOURCE_DIR)/.downloaded
 
 PATCH_DIR?= patches
 PATCH_PATTERN?= *.patch
-PATCHES= $(shell find $(PATCH_DIR) $(PARFAIT_PATCH_DIR) -type f \
-											-name '$(PATCH_PATTERN)' \
-                      	2>/dev/null | sort) $(EXTRA_PATCHES)
+PATCHES= # please don't patch -- update gfx-drm instead
 
 $(SOURCE_DIR)/.patched:	$(SOURCE_DIR)/.downloaded $(PATCHES)
 	$(MKDIR) $(@D)
 	cd $(SOURCE_DIR) && \
         $(GIT) checkout -f && \
               $(GIT) clean -f
-	for p in $(PATCHES); do \
-          $(GPATCH) -d $(@D) $(GPATCH_FLAGS) < $$p; \
-        done
-	@cd $(SOURCE_DIR); $(GIT) log -1 --format=%H > .downloaded
 	$(TOUCH) $@
 
 prep::	$(SOURCE_DIR)/.patched
 
-$(BUILD_DIR)/$(MACH)/.built: $(SOURCE_DIR)/.patched
+$(BUILD_DIR)/$(MACH)/.built: $(SOURCE_DIR)/.patched env.sh
 	cd $(SOURCE_DIR) && \
-		cat myenv.sh | \
-		(sed \
-			-e 's|^export NIGHTLY_OPTIONS=.*|export NIGHTLY_OPTIONS=\"$(NIGHTLY_OPTIONS)\"|' \
-			-e 's|^export VERSION=.*|export VERSION=\"$$(git log -1 --format=illumos-%h)\"|' \
-			-e 's|^export CODEMGR_WS=.*|export CODEMGR_WS=\"$$PWD\"|' \
-			-e 's|^export ON_CLOSED_BINS=.*|export ON_CLOSED_BINS=\"/opt/onbld/closed\"|'; \
-		echo export PYTHON_VERSION=\"$(PYTHON_VERSION)\"; \
-		echo export ONNV_BUILDNUM=$(ONNV_BUILDNUM); \
-		echo export PKGVERS_BRANCH=$(ONNV_BUILDNUM); \
-		) > env.sh && \
-	time $(ENV) -i /opt/onbld/bin/nightly env.sh
+		/opt/onbld/bin/bldenv ../env.sh "cd usr/src; make install"
+	cd $(SOURCE_DIR) && \
+		/opt/onbld/bin/bldenv ../env.sh "cd usr/src/pkg; make install"
 	@[ -d $(BUILD_DIR)/$(MACH) ] || $(MKDIR) $(BUILD_DIR)/$(MACH)
 	$(TOUCH) $@
 
@@ -90,6 +76,8 @@ PROTO_DIR=$(SOURCE_DIR)/proto/root_i386/
 
 build install: $(BUILD_DIR)/$(MACH)/.built
 
+# Could we just provide a transforms directory here instead?
+# BTW, what ../illumos-gate does here is gross.
 $(BUILD_DIR)/$(MACH)/publish.transforms:
 	echo "<transform set name=pkg.fmri -> edit value pkg://[^/]+/ pkg://$(PUBLISHER)/>" > \
 	$(BUILD_DIR)/$(MACH)/publish.transforms

--- a/components/openindiana/gfx-drm/env.sh
+++ b/components/openindiana/gfx-drm/env.sh
@@ -1,0 +1,77 @@
+#
+# CDDL HEADER START
+#
+# The contents of this file are subject to the terms of the
+# Common Development and Distribution License (the "License").
+# You may not use this file except in compliance with the License.
+#
+# You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+# or http://www.opensolaris.org/os/licensing.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# When distributing Covered Code, include this CDDL HEADER in each
+# file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+# If applicable, add the following below this CDDL HEADER, with the
+# fields enclosed by brackets "[]" replaced with your own identifying
+# information: Portions Copyright [yyyy] [name of copyright owner]
+#
+# CDDL HEADER END
+#
+# Copyright (c) 2005, 2010, Oracle and/or its affiliates. All rights reserved.
+# Copyright 2012 Joshua M. Clulow <josh@sysmgr.org>
+# Copyright 2013 Nexenta Systems, Inc. All rights reserved.
+#
+
+#	Configuration variables for the runtime environment of the nightly
+# build script and other tools for construction and packaging of releases.
+# This script is sourced by 'nightly' and 'bldenv' to set up the environment.
+# See illumos-gate/usr/src/tools/env for details.
+
+export NIGHTLY_OPTIONS='-DCFlnpr'
+
+# CODEMGR_WS - where is your workspace
+export CODEMGR_WS=`git rev-parse --show-toplevel`
+
+# This is a variable for the rest of the script - GATE doesn't matter to
+# nightly itself.
+GATE=`basename ${CODEMGR_WS}`
+
+# Maximum number of dmake jobs.  Small ws -- keep it simple.
+export DMAKE_MAX_JOBS=4
+
+# You should not need to change the next three lines
+export ATLOG="$CODEMGR_WS/log"
+export LOGFILE="$ATLOG/nightly.log"
+export MACH="$(uname -p)"
+
+# where is the proto area etc.
+export ROOT="$CODEMGR_WS/proto/root_${MACH}"
+export SRC="$CODEMGR_WS/usr/src"
+export MULTI_PROTO="no"
+
+#
+# Build environment variables, including version info for mcs, etc.
+# We want the git changeset hash.
+GIT_REV=`git rev-parse --short=10 HEAD`
+export VERSION="${GATE}:${GIT_REV}"
+export ONNV_BUILDNUM=152
+
+# export RELEASE='5.11'
+# export RELEASE_DATE='October 2007'
+
+# Package creation variables.
+export PKGARCHIVE="${CODEMGR_WS}/packages/${MACH}/nightly"
+export PKGPUBLISHER_REDIST='userland'
+
+# Package manifest format version.
+export PKGFMT_OUTPUT='v1'
+
+# Disable shadow compilation.
+export CW_NO_SHADOW='1'
+
+# Build tools - don't change these unless you know what you're doing.
+export ONBLD_TOOLS=/opt/onbld
+
+# see usr/src/pkg
+export PKGPUBLISHER=userland


### PR DESCRIPTION
We don't want nightly for gates based on on-skel.
Rather, just cd usr/src ; make ...

Also, I think we're probably better off providing an
env file here.  I had hoped we could fix some of the
problems with pkg publish by setting variables,
but that didn't seem to work for me.

I suspect we may need to change the pkg stuff
in the gfx-drm gate instead (get rid of example skel
stuff and add gfx-drm "for real", or whatever).
